### PR TITLE
Format exercise error correction

### DIFF
--- a/tutorials/pendulum/solutions/4_nodes.ipynb
+++ b/tutorials/pendulum/solutions/4_nodes.ipynb
@@ -155,7 +155,7 @@
     "        # START EXERCISE 1.1\n",
     "        # Add the  parameter *n* (the window size of the moving average filter) to the node specification.\n",
     "        spec.config.n = n  # Solution\n",
-    "        # START EXERCISE 1.1\n",
+    "        # END EXERCISE 1.1\n",
     "        return spec\n",
     "    \n",
     "\n",


### PR DESCRIPTION
Error in exercise format

<!--- Provide a general summary of your changes in the Title above -->

## Description
The following code segment can be found in the 4th tutorial of EAGERx about nodes:

```python
# START EXERCISE 1.1
# Add the  parameter *n* (the window size of the moving average filter) to the node specification.

# START EXERCISE 1.1
```

It is obvious that the second "START" is a typo and should be replaced by "END".


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTION](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.rst) guide (**required**).
- [ ] I have used semantic commit messages such that my PR is [semantic](https://github.com/zeke/semantic-pull-requests) (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make codestyle` (**required**).
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**).
- [x] I have ensured `make pytest` passes. (**required**).

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3 which is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
